### PR TITLE
Register poll form button

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -78,6 +78,7 @@
           "people-in": "People IN",
           "no-answers": "No one has enrolled yet!",
           "author-label": "Are you in?",
+          "form-button": "I am in",
           "author-placeholder": "Your name",
           "already-in": "You are already in!",
           "get-in": "Hell yeah!",

--- a/lang/es.json
+++ b/lang/es.json
@@ -166,7 +166,7 @@
   "footer": {
     "project-details": {
       "message": "PollMe es {project-link} realizado con {love-icon} por {community-link} bajo la {license-link}",
-      "project": "un projecto de código abierto",
+      "project": "un proyecto de código abierto",
       "community": "la comunidad",
       "license": "licencia MIT"
     },

--- a/lang/es.json
+++ b/lang/es.json
@@ -78,6 +78,7 @@
           "people-in": "Gente dentro",
           "no-answers": "¡Nadie se ha apuntado aún!",
           "author-label": "¿Te apuntas?",
+          "form-button": "Me apunto",
           "author-placeholder": "Tu nombre",
           "already-in": "¡Ya estás dentro!",
           "get-in": "¡Dios si!",

--- a/src/assets/css/components/button.css
+++ b/src/assets/css/components/button.css
@@ -5,6 +5,10 @@
   &:focus {
     outline: none;
   }
+
+  &[disabled] {
+    @apply .opacity-75;
+  }
 }
 
 /**

--- a/src/assets/css/components/button.css
+++ b/src/assets/css/components/button.css
@@ -1,6 +1,8 @@
 .btn {
-  @apply .rounded;
+  @apply .bg-grey-dark;
   @apply .px-3 .py-2;
+  @apply .rounded;
+  @apply .text-white;
 
   &:focus {
     outline: none;
@@ -9,31 +11,28 @@
   &[disabled] {
     @apply .opacity-75;
   }
-}
 
-/**
- *  PRIMARY
- */
+  /**
+   *  PRIMARY
+   */
 
-.btn-primary {
-  @apply .bg-primary;
-  @apply .text-white;
-}
+  &.btn-primary {
+    @apply .bg-primary;
+  }
 
-/**
- *  SECONDARY
- */
+  /**
+   *  SECONDARY
+   */
 
-.btn-secondary {
-  @apply .bg-secondary;
-  @apply .text-white;
-}
+  &.btn-secondary {
+    @apply .bg-secondary;
+  }
 
-/**
- *  TERTIARY
- */
+  /**
+   *  TERTIARY
+   */
 
-.btn-tertiary {
-  @apply .bg-tertiary;
-  @apply .text-white;
+  &.btn-tertiary {
+    @apply .bg-tertiary;
+  }
 }

--- a/src/components/FileUploader.vue
+++ b/src/components/FileUploader.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
-    <button :class="{ 'opacity-75': loading }" @click="$refs.fileInput.click()"
-      class="btn btn-tertiary" :disabled="loading" >
+    <button class="btn btn-tertiary" :disabled="loading" @click="$refs.fileInput.click()" >
       <font-awesome-icon :icon="loading ? 'spinner' : 'upload'" :spin="loading" >
       </font-awesome-icon>
       <span v-show="!loading && text" class="ml-1">{{ text }}</span>

--- a/src/polls/create/components/NewPollForm.vue
+++ b/src/polls/create/components/NewPollForm.vue
@@ -25,9 +25,9 @@
         </textarea>
       </div>
     </div>
-    <button :class="{ 'opacity-75': $v.$invalid }" :disabled="$v.$invalid"
-      type="submit" class="sticky pin-b py-4 bg-secondary">
-      <div class="text-center text-white text-xl">
+    <button type="submit" class="sticky pin-b py-4 btn btn-secondary rounded-none"
+      :disabled="$v.$invalid" >
+      <div class="text-center text-xl">
         <span v-t="'polls.new.form.submit-button'"></span>
         <font-awesome-icon icon="plus" class="ml-1" ></font-awesome-icon>
       </div>

--- a/src/polls/poll/fill/components/RegistrationPoll.vue
+++ b/src/polls/poll/fill/components/RegistrationPoll.vue
@@ -11,14 +11,16 @@
           </button>
         </div>
         <form v-else @submit.prevent="submit" class="flex" ref="anonymous-vote-container">
-          <label for="name" v-t="`polls.types.${poll.type}.fill.author-label`"
-            class="text-white font-semibold flex-no-shrink pl-2 pr-4 flex items-center"></label>
           <div class="flex-1 text-grey-darker" >
             <input v-model.trim="name" @input="$v.name.$touch()"
               v-bind:class="{ 'border-red': $v.name.$error }"
               :placeholder="$t(`polls.types.${poll.type}.fill.author-placeholder`)"
               id="name" type="text" class="shadow-none border-transparent border-2">
           </div>
+          <button class="btn btn-primary ml-2" type="submit" :disabled="$v.$invalid">
+            <span v-t="`polls.types.${poll.type}.fill.form-button`"></span>
+            <font-awesome-icon icon="sign-in-alt" fixed-width></font-awesome-icon>
+          </button>
         </form>
       </template>
       <div v-else class="flex" ref="remove-vote-container">

--- a/src/user/login/LoginForm.vue
+++ b/src/user/login/LoginForm.vue
@@ -29,8 +29,8 @@
         </p>
       </div>
     </div>
-    <button :class="{ 'opacity-75': $v.$invalid }" :disabled="$v.$invalid"
-      type="submit" class="sticky pin-b py-4 bg-secondary text-center text-white text-xl">
+    <button class="sticky pin-b py-4 btn btn-secondary rounded-none text-center text-xl"
+      type="submit" :disabled="$v.$invalid">
       <font-awesome-icon icon="sign-in-alt" class="mr-1" ></font-awesome-icon>
       <span v-t="'user.login.submit'"></span>
     </button>

--- a/src/user/login/RegisterForm.vue
+++ b/src/user/login/RegisterForm.vue
@@ -49,8 +49,8 @@
           </p>
         </div>
       </div>
-      <button :class="{ 'opacity-75': $v.$invalid }" :disabled="$v.$invalid"
-        type="submit" class="sticky pin-b py-4 bg-secondary text-center text-white text-xl">
+      <button class="sticky pin-b py-4 btn btn-secondary rounded-none text-center text-xl"
+        type="submit" :disabled="$v.$invalid" >
         <font-awesome-icon icon="user-plus" class="mr-1" ></font-awesome-icon>
         <span v-t="'user.register.submit'"></span>
       </button>

--- a/src/user/profile/UserProfile.vue
+++ b/src/user/profile/UserProfile.vue
@@ -7,7 +7,7 @@
           :loading="updatingAvatar" :max-size="avatarMaxSize"
           @files-ready="updateAvatar" @not-valid-error="fileError = true" ></FileUploader>
         <button v-if="profile.photoUrl" @click="updateAvatar()" :disabled="updatingAvatar"
-          class="btn bg-grey-dark ml-2 text-white">
+          class="btn ml-2">
           <font-awesome-icon icon="trash-alt">
           </font-awesome-icon>
         </button>
@@ -101,9 +101,8 @@
           </div>
         </div>
       </div>
-      <button v-show="hasChanges" :class="{ 'opacity-75': $v.$invalid || loading }"
-        :disabled="$v.$invalid || loading"
-        type="submit" class="sticky pin-b py-4 bg-secondary text-center text-white text-xl">
+      <button v-show="hasChanges" :disabled="$v.$invalid || loading"
+        type="submit" class="sticky pin-b py-4 btn btn-secondary rounded-none text-center text-xl">
         <template v-if="!loading">
           <font-awesome-icon icon="edit" class="mr-1" ></font-awesome-icon>
           <span v-t="'user.profile.submit-button'"></span>


### PR DESCRIPTION
Add a submit button on the anonymous registration poll form, so the keyboard enter key is not the only way to send the vote.
- Fix a **Spanish translation at the footer**
- Add a **submit button** to registration poll **anonymous form**
- Refactor the CSS **button** component to apply **opacity when disabled**